### PR TITLE
feat(c-chain-indexer): parameterize start_index + history_drop via envsubst

### DIFF
--- a/template-configs/c-chain-indexer.template.toml
+++ b/template-configs/c-chain-indexer.template.toml
@@ -3,6 +3,7 @@ num_parallel_req = 100 # the number of threads doing requests to the chain in pa
 batch_size = 1000 # the number of blocks that will be pushed to a database in a batch (should be divisible by num_parallel_req)
 log_range = 10 # the size of the interval of blocks used to request logs in each request; suggested value is log_range = batch_size / num_parallel_req; note that a blockchain node might have an upper bound on this
 new_block_check_millis = 1000 # interval for checking for new blocks
+start_index = ${START_INDEX:-0} # block to start indexing from (0 = network genesis)
 
 # standard config
 [[indexer.collect_transactions]]
@@ -61,7 +62,7 @@ topic = "undefined"
 [db]
 log_queries = false
 drop_table_at_start = false
-history_drop = 3628800 # 42 days
+history_drop = ${HISTORY_DROP:-3628800} # seconds to keep (42 days = 3628800)
 
 [logger]
 level = "INFO"


### PR DESCRIPTION
## Summary

Replace hardcoded start_index and history_drop values in
template-configs/c-chain-indexer.template.toml with envsubst placeholders,
matching the pattern already used for system-client, ftso-client, fdc-client
and fast-updates templates.

## Why

populate_config.sh line 181 calls envsubst < template-configs/c-chain-indexer.template.toml
but the template currently has hardcoded values for start_index and history_drop.
Other templates use $VAR placeholders that get substituted from .env.

This forces operators with custom values to maintain a downstream fork or apply
post-clone patches - both error-prone.

## Change



## Backward compatibility

Fully backward-compatible via default envsubst syntax:
- start_index defaults to 0 (network genesis) - matches previous absence of explicit setting
- history_drop defaults to 3628800 (42 days) - matches previous hardcoded value

If operators do not set START_INDEX / HISTORY_DROP in their .env,
populate_config.sh produces same output as before this PR.

## Test plan

- bash populate_config.sh with empty .env -> produces same output as today (defaults)
- bash populate_config.sh with START_INDEX=121000000 HISTORY_DROP=0 -> produces operator-customized output

## Operator pain-point this fixes

Multiple operators (us included) have had to maintain downstream forks of
this template just to parameterize these two values. This PR removes that need.